### PR TITLE
Modify fetchItem to allow overriding of fetch method

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -12,7 +12,7 @@ var fsExtra = require('fs-extra')
 var path = require('path')
 var pathExtra = require('path-extra');
 var request = require('request')
-var urlRegex = require('url-regex')
+var validUrl = require('valid-url');
 var uuid = require('uuid')
 var gunzip = require('gunzip-maybe')
 var tar = require('tar-fs')
@@ -21,9 +21,9 @@ var isThere = require('is-there')
 
 
 module.exports = function (state, callback, error) {
-    fetchItem(state, state.inputs[0], 'template', function(state) {
+    fetchTemplate(state, state.inputs[0], function(state) {
         if(typeof state.inputs[1] !== 'undefined') {
-            fetchItem(state, state.inputs[1], 'project', function(state) {
+            fetchProject(state, state.inputs[1], function(state) {
                 callback(state)
             }, error)
         } else {
@@ -32,61 +32,23 @@ module.exports = function (state, callback, error) {
     }, error)
 }
 
-var fetchItem = function (state, input, type, callback, error) {
-    var item = null
+var fetchTemplate = function(state, input, callback, error) {
     var isGitHub = input.match(/^(?!\.)[A-Za-z0-9\-_]+\/[A-Za-z0-9\-_]+$/g)
-    var isGit = isGitUrl(input)
-    var isURL = urlRegex({exact: true}).test(input)
-    var isJSON = input.match(/^("(\\.|[^"\\\n\r])*?"|[,:{}\[\]0-9.\-+Eaeflnr-u \n\r\t])+?$/g)
-    var isFile = input.match(/[^\\]*\.(\w+)$/g)
     var isFolder = input.match(/^(\.|\.\.)(\/.+)+\/?$/g)
+    var isGit = isGitUrl(input) || validUrl.isUri(input)
 
-    var fetchType = state.options.inputType ? state.options.inputType :
-                    isGitHub  ? 'github':
-                    isGit     ? 'git':
-                    isURL     ? 'url':
-                    isJSON    ? 'json':
-                    isFile    ? 'file':
-                    isFolder  ? 'folder' : undefined;
-
-    if (fetchType === 'github') {
-        fetchGitHub(state, input, type, callback, error)
-    } else if (fetchType === 'git') {
-        fetchGit(state, input, type, callback, error)
-    } else if (fetchType === 'url') {
-        fetchURL(state, input, type, callback, error)
-    } else if (fetchType === 'json') {
-        fetchJSON(state, input, type, callback, error)
-    } else if (fetchType === 'file'){
-        fetchFile(state, input, type, callback, error)
-    } else if (fetchType === 'folder'){
-        fetchFolder(state, input, type, callback, error)
+    if(isGitHub) {
+        fetchGitHub(state, input, callback, error);
+    } else if(isFolder) {
+        fetchFolder(state, input, callback, error);
+    } else if(isGit) {
+        fetchGit(state, input, callback, error);
     } else {
         error(state, { 'message':'Unable to match "'+input+'" with an action.' })
     }
 }
 
-var fetchGit = function (state, input, type, callback, error) {
-    var exec = require('child_process').exec
-    var tmpPath = pathExtra.tempdir()+'/'+uuid.v1()
-    var command = "git clone "+input+" "+tmpPath
-
-    exec(command, function(error, stdout, stderr) {
-        state[type] = {
-            input: input,
-            source: 'git',
-            tmp: tmpPath
-        }
-
-        if(isThere(tmpPath + '/.git')) {
-            fsExtra.removeSync(tmpPath + '/.git')
-        }
-
-        callback(state)
-    })
-}
-
-var fetchGitHub = function (state, input, type, callback, error) {
+var fetchGitHub = function (state, input, callback, error) {
     var tmpPath = pathExtra.tempdir()+'/'+uuid.v1()
 
     // setup the tmp path
@@ -114,7 +76,7 @@ var fetchGitHub = function (state, input, type, callback, error) {
             }).pipe(gunzip()).pipe(tar.extract(tmpPath))
 
             stream.on('finish', function () {
-                state[type] = {
+                state.template = {
                     input: input,
                     source: 'github',
                     tmp: tmpPath + '/' + repoDetails.name + '-' + repoDetails.default_branch
@@ -123,6 +85,63 @@ var fetchGitHub = function (state, input, type, callback, error) {
             })
         })
     })
+}
+
+var fetchFolder = function (state, input, callback, error) {
+    var folder = path.basename(input)
+    var tmpPath = pathExtra.tempdir()+'/'+uuid.v1()
+
+    // setup the tmp path
+    fsExtra.mkdirsSync(tmpPath)
+
+    fsExtra.copySync(input, tmpPath)
+
+    if(isThere(tmpPath + '/.git')) {
+        fsExtra.removeSync(tmpPath + '/.git')
+    }
+
+    state.template = {
+        input: input,
+        source: 'folder',
+        tmp: tmpPath
+    }
+    callback(state)
+}
+
+var fetchGit = function (state, input, callback, error) {
+    var exec = require('child_process').exec
+    var tmpPath = pathExtra.tempdir()+'/'+uuid.v1()
+    var command = "git clone "+input+" "+tmpPath
+
+    exec(command, function(error, stdout, stderr) {
+        state.template = {
+            input: input,
+            source: 'git',
+            tmp: tmpPath
+        }
+
+        if(isThere(tmpPath + '/.git')) {
+            fsExtra.removeSync(tmpPath + '/.git')
+        }
+
+        callback(state)
+    })
+}
+
+var fetchProject = function(state, input, callback, error) {
+    var isURL = validUrl.isUri(input)
+    var isJSON = input.match(/^("(\\.|[^"\\\n\r])*?"|[,:{}\[\]0-9.\-+Eaeflnr-u \n\r\t])+?$/g)
+    var isFile = input.match(/[^\\]*\.(\w+)$/g)
+    console.log(isJSON);
+    if(isURL) {
+        fetchURL(state, input, callback, error)
+    } else if(isJSON) {
+        fetchJSON(state, input, callback, error)
+    } else if(isFile) {
+        fetchFile(state, input, callback, error)
+    } else {
+        error(state, { 'message':'Unable to match "'+input+'" with an action.' })
+    }
 }
 
 var fetchURL = function (state, input, type, callback, error) {
@@ -173,25 +192,4 @@ var fetchFile = function (state, input, type, callback, error) {
             callback(state)
         })
     })
-}
-
-var fetchFolder = function (state, input, type, callback, error) {
-    var folder = path.basename(input)
-    var tmpPath = pathExtra.tempdir()+'/'+uuid.v1()
-
-    // setup the tmp path
-    fsExtra.mkdirsSync(tmpPath)
-
-    fsExtra.copySync(input, tmpPath)
-
-    if(isThere(tmpPath + '/.git')) {
-        fsExtra.removeSync(tmpPath + '/.git')
-    }
-
-    state[type] = {
-        input: input,
-        source: 'folder',
-        tmp: tmpPath
-    }
-    callback(state)
 }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -132,7 +132,7 @@ var fetchProject = function(state, input, callback, error) {
     var isURL = validUrl.isUri(input)
     var isJSON = input.match(/^("(\\.|[^"\\\n\r])*?"|[,:{}\[\]0-9.\-+Eaeflnr-u \n\r\t])+?$/g)
     var isFile = input.match(/[^\\]*\.(\w+)$/g)
-    console.log(isJSON);
+
     if(isURL) {
         fetchURL(state, input, callback, error)
     } else if(isJSON) {
@@ -144,7 +144,7 @@ var fetchProject = function(state, input, callback, error) {
     }
 }
 
-var fetchURL = function (state, input, type, callback, error) {
+var fetchURL = function (state, input, callback, error) {
     var fileName = path.basename(input)
     var tmpPath = pathExtra.tempdir()+'/'+uuid.v1()
 
@@ -156,7 +156,7 @@ var fetchURL = function (state, input, type, callback, error) {
         var stream = response.pipe(fs.createWriteStream(tmpPath + '/data.json'))
 
         stream.on('finish', function () {
-            state[type] = {
+            state.project = {
                 input: input,
                 source: 'url',
                 tmp: tmpPath + '/data.json'
@@ -166,15 +166,15 @@ var fetchURL = function (state, input, type, callback, error) {
     })
 }
 
-var fetchJSON = function (state, input, type, callback, error) {
-    state[type] = {
+var fetchJSON = function (state, input, callback, error) {
+    state.project = {
         input: input,
         source: 'json'
     }
     callback(state)
 }
 
-var fetchFile = function (state, input, type, callback, error) {
+var fetchFile = function (state, input, callback, error) {
     var fileName = path.basename(input)
     var tmpPath = pathExtra.tempdir()+'/'+uuid.v1()
 
@@ -184,7 +184,7 @@ var fetchFile = function (state, input, type, callback, error) {
         var stream = fs.createReadStream(input).pipe(fs.createWriteStream(tmpPath + '/data.json'))
 
         stream.on('finish', function () {
-            state[type] = {
+            state.project = {
                 input: input,
                 source: 'file',
                 tmp: tmpPath + '/data.json'

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -41,17 +41,25 @@ var fetchItem = function (state, input, type, callback, error) {
     var isFile = input.match(/[^\\]*\.(\w+)$/g)
     var isFolder = input.match(/^(\.|\.\.)(\/.+)+\/?$/g)
 
-    if (isGitHub) {
+    var fetchType = state.options.inputType ? state.options.inputType :
+                    isGitHub  ? 'github':
+                    isGit     ? 'git':
+                    isURL     ? 'url':
+                    isJSON    ? 'json':
+                    isFile    ? 'file':
+                    isFolder  ? 'folder' : undefined;
+
+    if (fetchType === 'github') {
         fetchGitHub(state, input, type, callback, error)
-    } else if (isGit) {
+    } else if (fetchType === 'git') {
         fetchGit(state, input, type, callback, error)
-    } else if (isURL) {
+    } else if (fetchType === 'url') {
         fetchURL(state, input, type, callback, error)
-    } else if (isJSON) {
+    } else if (fetchType === 'json') {
         fetchJSON(state, input, type, callback, error)
-    } else if (isFile){
+    } else if (fetchType === 'file'){
         fetchFile(state, input, type, callback, error)
-    } else if (isFolder){
+    } else if (fetchType === 'folder'){
         fetchFolder(state, input, type, callback, error)
     } else {
         error(state, { 'message':'Unable to match "'+input+'" with an action.' })

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "path-extra": "^3.0.0",
     "request": "^2.69.0",
     "tar-fs": "^1.9.0",
-    "url-regex": "^3.1.0",
-    "uuid": "^2.0.1"
+    "uuid": "^2.0.1",
+    "valid-url": "^1.0.9"
   },
   "bin": "./bin.js",
   "files": [


### PR DESCRIPTION
Due to the way Team Foundation Server has its endpoints set up, the url doesn't look like a git url, but needs to be requested like one, this commit allows a way to tell pollinate to do that. I'm certain there will be other use cases.

Let me know what you think about this, I'll add a couple of lines to the docs too if it's useful.

Just for reference, the url looks like: 
`http://myserv.com/tfs/project/collection/_git/template-project` which doesn't really match any of the fetch methods, but should be done using git clone to take advantage of the credential manager.
