### PR TITLE
Removing the "target" input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,17 +172,6 @@ You can pass project data as a JSON endpoint
 $ pollinate howardroark/webapp https://example.com/json/data
 ```
 
-You can supply a target directory (will create directories that do not exist).
-
-```
-$ pollinate howardroark/webapp target
-```
-or
-
-```
-$ pollinate howardroark/webapp /target/directory data.json
-```
-
 You can generate from the default data in the template
 ```
 $ pollinate howardroark/webapp

--- a/lib/init.js
+++ b/lib/init.js
@@ -52,26 +52,15 @@ module.exports = function (state, callback) {
         callback({ 'message': 'Unable to match "' + state.template.input + '" with an action.' });
     }
 
+    // Setup the project object if the input is present
+    if (state.inputs[1] !== undefined) {
+        state.project = {};
+        state.project.input = state.inputs[1];
 
-    if (state.inputs.length > 1) {
+        state.project.source = getProjectSource(state.project.input);
 
-        // If second option can't be matched with a project source then set it as `target` and check the next index
-        var projectIndex = 1;
-        if (!getProjectSource(state.inputs[projectIndex])) {
-            state.target = state.inputs[projectIndex];
-            projectIndex = 2;
-        }
-
-        // Setup the project object if the input is present
-        if (state.inputs[projectIndex] !== undefined) {
-            state.project = {};
-            state.project.input = state.inputs[projectIndex];
-
-            state.project.source = getProjectSource(state.project.input);
-
-            if (!state.project.source) {
-                callback({ 'message': 'Unable to match "' + state.project.input + '" with an action.' });
-            }
+        if (!state.project.source) {
+            callback({ 'message': 'Unable to match "' + state.project.input + '" with an action.' });
         }
     }
 

--- a/lib/move.js
+++ b/lib/move.js
@@ -17,8 +17,7 @@ var mkdirp = require('mkdirp');
 var mv = require('mv');
 
 module.exports = function (state, callback) {
-    var move = state.data.move,
-        target = state.data.name;
+    var move = state.data.move;
 
     async.series([
         // Move around all the items specified in the schema
@@ -56,23 +55,9 @@ module.exports = function (state, callback) {
                 next(null);
             });
         },
-        // Check if there is a specified target path to for everything to go, and make it
+        // Move all the files to the relative path "{{ name }}"
         function (next) {
-            if (state.target !== undefined) {
-                target = state.target;
-                mkdirp(target, function (err) {
-                    if (err) {
-                        next(err);
-                        return;
-                    }
-                    next(null);
-                });
-            }
-            next(null);
-        },
-        // Move all the files to the target path
-        function (next) {
-            mv(state.template.tmp, target, function (err) {
+            mv(state.template.tmp, state.data.name, function (err) {
                 if (err) {
                     next(err);
                     return;


### PR DESCRIPTION
The "target" thing was basically a way that you could also tell the cli where the {{ name }} dir will end up (vs relative to where you are).  I just added it cause i though it would be neat.  Though I think all it does is confuse things.  It's nice to be able to count on things ending up relative to where the command is being run.