### PR TITLE
Feature/replace fs extra copy

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -11,7 +11,7 @@
 
 var fs = require('fs');
 var mkdirp = require('mkdirp');
-var copy = require('copy');
+var cp = require('cp');
 var rimraf = require('rimraf');
 var path = require('path');
 var ospath = require('ospath');
@@ -74,7 +74,7 @@ var fetchDirectory = function (state, callback) {
             callback(err);
             return;
         }
-        copy(input, tmpPath, function (err) {
+        cp(input, tmpPath, function (err) {
             if (err) {
                 callback(err);
                 return;

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -12,6 +12,7 @@
 var fs = require('fs');
 var fsExtra = require('fs-extra');
 var mkdirp = require('mkdirp');
+var copy = require('copy');
 var path = require('path');
 var ospath = require('ospath');
 var request = require('request');
@@ -73,7 +74,7 @@ var fetchDirectory = function (state, callback) {
             callback(err);
             return;
         }
-        fsExtra.copy(input, tmpPath, function (err) {
+        copy(input, tmpPath, function (err) {
             if (err) {
                 callback(err);
                 return;

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -10,7 +10,6 @@
 'use strict';
 
 var fs = require('fs');
-var fsExtra = require('fs-extra');
 var mkdirp = require('mkdirp');
 var copy = require('copy');
 var rimraf = require('rimraf');

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -11,7 +11,7 @@
 
 var fs = require('fs');
 var mkdirp = require('mkdirp');
-var cp = require('cp');
+var cpr = require('cpr');
 var rimraf = require('rimraf');
 var path = require('path');
 var ospath = require('ospath');
@@ -74,7 +74,7 @@ var fetchDirectory = function (state, callback) {
             callback(err);
             return;
         }
-        cp(input, tmpPath, function (err) {
+        cpr(input, tmpPath, function (err) {
             if (err) {
                 callback(err);
                 return;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "inquirer-compatibility-fork": "^2.0.1",
     "is-directory": "^0.3.1",
     "mkdirp": "^0.5.1",
+    "copy": "^0.1.1",
     "mv": "^2.1.1",
     "node-dir": "^0.1.11",
     "nunjucks": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "inquirer-compatibility-fork": "^2.0.1",
     "is-directory": "^0.3.1",
     "mkdirp": "^0.5.1",
-    "copy": "^0.1.1",
+    "copy": "^0.3.0",
     "mv": "^2.1.1",
     "node-dir": "^0.1.11",
     "nunjucks": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "inquirer-compatibility-fork": "^2.0.1",
     "is-directory": "^0.3.1",
     "mkdirp": "^0.5.1",
-    "copy": "^0.3.0",
+    "cp": "^0.2.0",
     "mv": "^2.1.1",
     "node-dir": "^0.1.11",
     "nunjucks": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "inquirer-compatibility-fork": "^2.0.1",
     "is-directory": "^0.3.1",
     "mkdirp": "^0.5.1",
-    "cp": "^0.2.0",
+    "cpr": "^2.0.2",
     "mv": "^2.1.1",
     "node-dir": "^0.1.11",
     "nunjucks": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "cli-argparse": "^1.1.0",
     "commander": "^2.9.0",
     "extend": "^3.0.0",
-    "fs-extra": "^2.0.0",
     "globby": "^6.1.0",
     "gunzip-maybe": "^1.3.1",
     "hjson": "^2.3.1",


### PR DESCRIPTION
Basically `fsExtra` stopped working because this project is setup to test with `0.10.0`.  So I replaced `fsExtra.remove` and `fsExtra.mkdirs` with `rimraf` and `mkdirp`.  All in all I'd like to follow the unix philosophy and have each module do one thing.  Makes it more simple to swap them in/out if need be.

Now just need to replace `fsExtra.copy`...